### PR TITLE
Add Environment variables

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,5 +2,4 @@ GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
-FACEBOOK_APP_ID=your_facebook_app_id
-FACEBOOK_APP_SECRET=your_facebook_app_secret
+FRONTEND_ORIGIN=http://localhost:5173

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -23,7 +23,7 @@ app.use(passport.authenticate('session'));
 
 app.use(
   cors({
-    origin: "http://localhost:5173",
+    origin: process.env.FRONTEND_ORIGIN || "http://localhost:5173",
     methods: "GET,POST,PUT,DELETE",
     credentials: true,
   })

--- a/apps/backend/src/passport.ts
+++ b/apps/backend/src/passport.ts
@@ -1,22 +1,19 @@
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const GithubStrategy = require("passport-github2").Strategy;
-const FacebookStrategy = require("passport-facebook").Strategy;
 import passport from "passport";
 import dotenv from "dotenv";
 import { db } from "./db";
 
 dotenv.config();
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "your_google_client_id";
-const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || "your_google_client_secret";
-const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID || "your_github_client_id";
-const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET || "your_github_client_secret";
-const FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID || "your_facebook_app_id";
-const FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET || "your_facebook_app_secret";
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID 
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET
+const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID 
+const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET
 
 
 export function initPassport() {
 
-  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET || !FACEBOOK_APP_ID || !FACEBOOK_APP_SECRET) {
+  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
     throw new Error('Missing environment variables for authentication providers');
   }
 

--- a/apps/backend/src/router/auth.ts
+++ b/apps/backend/src/router/auth.ts
@@ -3,8 +3,8 @@ import passport from 'passport';
 import jwt from 'jsonwebtoken';
 import { db } from '../db';
 const router = Router();
-
-const CLIENT_URL = 'http://localhost:5173/game/random';
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || "http://localhost:5173";
+const CLIENT_URL = `${FRONTEND_ORIGIN}/game/random`;
 const JWT_SECRET = process.env.JWT_SECRET || 'your_secret_key';
 
 interface User {
@@ -46,7 +46,7 @@ router.get('/logout', (req: Request, res: Response) => {
       res.status(500).json({ error: 'Failed to log out' });
     } else {
       res.clearCookie('jwt');
-      res.redirect('http://localhost:5173/');
+      res.redirect(FRONTEND_ORIGIN);
     }
   });
 });

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_BACKEND_URL=http://localhost:3000
+VITE_WS_URL=ws://localhost:8080

--- a/apps/frontend/src/hooks/useSocket.ts
+++ b/apps/frontend/src/hooks/useSocket.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { useUser } from "@repo/store/useUser";
 
-const WS_URL = "ws://localhost:8080";
+const WS_URL = import.meta.env.VITE_WS_URL || "ws://localhost:8080";
 
 export const useSocket = () => {
     const [socket, setSocket] = useState<WebSocket | null>(null);

--- a/apps/frontend/src/screens/Login.tsx
+++ b/apps/frontend/src/screens/Login.tsx
@@ -2,7 +2,7 @@ import Google from "../assets/google.png";
 import Github from "../assets/github.png";
 import { useNavigate } from 'react-router-dom';
 
-const BACKEND_URL = "http://localhost:3000";
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL|| "http://localhost:3000";
 
 const Login = () => {
   const navigate = useNavigate();

--- a/packages/store/src/atoms/user.ts
+++ b/packages/store/src/atoms/user.ts
@@ -1,7 +1,7 @@
 
 import { atom, selector } from "recoil";
-
-export const BACKEND_URL = "http://localhost:3000";
+//@ts-ignore
+export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:3001";
 export interface User {
     token: string;
     id: string;


### PR DESCRIPTION
# PR Description

## The most common problem @hkirat face was typing hardcoded values throughout the project and keep saying You should use ENV
This PR added the .env.sample file throughout frontend and backend to improve the running experience

- Remove Facebook strategy as we were not using it any where
- Remove the Short-circuit evaluation from passport.ts file which uses the Logical OR operator as It stops the backend to throw error if the .env file is missing
- Used `//@ts-ignore` comment in the user atom to avoid import.meta error because it's allowed in vite project not in commonjs module


