### PR TITLE
(RN)fix: added label for PlayerStrip

### DIFF
--- a/apps/native/app/game/index.tsx
+++ b/apps/native/app/game/index.tsx
@@ -68,7 +68,7 @@ const ChessBoard = () => {
         </ScrollView>
       </View>
 
-      <PlayerStrip />
+      <PlayerStrip label="Player 2" />
       <View>
         <Chessboard
           ref={chessboardRef}
@@ -88,19 +88,19 @@ const ChessBoard = () => {
           }}
         />
       </View>
-      <PlayerStrip />
+      <PlayerStrip label="Player 1" />
     </View>
   );
 };
 
 export default ChessBoard;
 
-const PlayerStrip = () => {
+const PlayerStrip = ({ label = "Player 1" }) => {
   return (
     <View style={styles.playerStrip}>
       <View style={styles.playerAvatar}></View>
       <View>
-        <Text style={styles.name}>Player 1</Text>
+        <Text style={styles.name}>{label}</Text>
       </View>
     </View>
   );


### PR DESCRIPTION
Player names was showing as Player 1 for both the players.
![RNFixPlayerStrip](https://github.com/code100x/chess/assets/47496910/35b544c3-f12c-4070-8692-1f9493d35fa1)


I added dynamic label for player name so we can pass player name in future if we want.
![Fix](https://github.com/code100x/chess/assets/47496910/be00a404-92a8-4976-9b3b-6064ce534526)
