### PR TITLE
fix: login routes

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { Landing } from './screens/Landing';
 import { Game } from './screens/Game';
 import Login from './screens/Login';
@@ -26,8 +26,8 @@ function AuthApp() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/login" element={user ? <Game /> : <Login />} />
-        <Route path="/game/:gameId" element={user ? <Game /> : <Login />} />
+        <Route path="/login" element={ <Login />} />
+        <Route path="/game/:gameId" element={user?<Game />: <Navigate to={"/login"}/>} />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/frontend/src/screens/Landing.tsx
+++ b/apps/frontend/src/screens/Landing.tsx
@@ -1,8 +1,19 @@
 import { useNavigate } from "react-router-dom"
 import { Button } from "../components/Button";
+import { useUser } from "@repo/store/useUser";
+import { useEffect } from "react";
 
 export const Landing = () => {
     const navigate = useNavigate();
+    const user = useUser();
+  
+    useEffect(()=>{
+        if(user){
+            navigate("game/random");
+            return;
+        }
+    }, []);
+    
     return (
         <div className="w-full bg-[#302E2B] mx-auto">
             <header className="bg-[#262522] font-mono text-white pt-8 pb-9 w-full shadow-lg">

--- a/apps/frontend/src/screens/Login.tsx
+++ b/apps/frontend/src/screens/Login.tsx
@@ -1,12 +1,15 @@
 import Google from '../assets/google.png';
 import Github from '../assets/github.png';
 import { useNavigate } from 'react-router-dom';
+import { useUser } from '@repo/store/useUser';
+import { useEffect } from 'react';
 
 const BACKEND_URL =
   import.meta.env.VITE_APP_BACKEND_URL ?? 'http://localhost:3000';
 
 const Login = () => {
   const navigate = useNavigate();
+  const user = useUser();
 
   const google = () => {
     window.open(`${BACKEND_URL}/auth/google`, '_self');
@@ -15,6 +18,13 @@ const Login = () => {
   const github = () => {
     window.open(`${BACKEND_URL}/auth/github`, '_self');
   };
+
+  useEffect(()=>{
+    if(user){
+      navigate("/game/random");
+      return;
+    }
+  }, [])
 
   return (
     <div className="flex flex-col items-center justify-center h-screen bg-gray-900 text-white">


### PR DESCRIPTION
This pr fixes #181.

It renders components and redirects to correct url based on authentication status.

If users are not logged in -
1. for "/" route, renders landing page - 
![image](https://github.com/code100x/chess/assets/149887791/63c58b6c-bdf4-44ae-bfd0-0016e1d24962)

2. for "/login" and "/game/:gameid" routes, renders login page
<img width="657" alt="Screenshot 2024-04-22 at 4 10 35 PM" src="https://github.com/code100x/chess/assets/149887791/c6a80cd4-202e-4293-891e-cf633eba38b2">

If users are logged in -
1. for "/", and "/login" routes, renders game page
<img width="766" alt="Screenshot 2024-04-22 at 4 07 17 PM" src="https://github.com/code100x/chess/assets/149887791/82c2b384-74ba-4b1f-abe4-58c270950c9f">



 



