### PR TITLE
[Fix]: Created docker-compose dev environment and refactored the use of PrismaClient

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/.next
+**/dist

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.5.2
+# based on: https://github.com/vercel/turbo/blob/main/examples/with-docker/apps/api/Dockerfile
+
+FROM node:20.2-alpine3.17 as base
+
+# adding apk deps to avoid node-gyp related errors and some other stuff. adds turborepo globally
+RUN apk add -f --update --no-cache --virtual .gyp nano bash libc6-compat python3 make g++ \
+      && yarn global add turbo \
+      && apk del .gyp
+
+#############################################
+FROM base AS pruned
+WORKDIR /app
+ARG APP
+
+COPY . .
+
+# see https://turbo.build/repo/docs/reference/command-line-reference#turbo-prune---scopetarget
+RUN turbo prune --scope=$APP --docker
+
+#############################################
+FROM base AS installer
+WORKDIR /app
+ARG APP
+
+COPY --from=pruned /app/out/json/ .
+COPY --from=pruned /app/out/yarn.lock yarn.lock
+
+# Forces the layer to recreate if the app's package.json changes
+COPY apps/${APP}/package.json /app/apps/${APP}/package.json
+
+# see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypecache
+RUN \
+      --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
+      yarn --prefer-offline --frozen-lockfile
+
+COPY --from=pruned /app/out/full/ .
+COPY turbo.json turbo.json
+
+# For example: `--filter=frontend^...` means all of frontend's dependencies will be built, but not the frontend app itself (which we don't need to do for dev environment)
+RUN turbo run build --no-cache --filter=${APP}^...
+
+# re-running yarn ensures that dependencies between workspaces are linked correctly
+RUN \
+      --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
+      yarn --prefer-offline --frozen-lockfile
+
+#############################################
+FROM base AS runner
+WORKDIR /app
+ARG APP
+ARG START_COMMAND=dev
+
+COPY --from=installer /app .
+COPY init-db.sh /app/packages/db/init-db.sh
+RUN chmod +x /app/packages/db/init-db.sh
+
+EXPOSE 8080
+EXPOSE 5173
+EXPOSE 3000
+CMD yarn workspace ${APP} ${START_COMMAND}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.5.2
-# based on: https://github.com/vercel/turbo/blob/main/examples/with-docker/apps/api/Dockerfile
 
 FROM node:20.2-alpine3.17 as base
 
-# adding apk deps to avoid node-gyp related errors and some other stuff. adds turborepo globally
 RUN apk add -f --update --no-cache --virtual .gyp nano bash libc6-compat python3 make g++ \
       && yarn global add turbo \
       && apk del .gyp
@@ -15,7 +13,6 @@ ARG APP
 
 COPY . .
 
-# see https://turbo.build/repo/docs/reference/command-line-reference#turbo-prune---scopetarget
 RUN turbo prune --scope=$APP --docker
 
 #############################################
@@ -26,10 +23,8 @@ ARG APP
 COPY --from=pruned /app/out/json/ .
 COPY --from=pruned /app/out/yarn.lock yarn.lock
 
-# Forces the layer to recreate if the app's package.json changes
 COPY apps/${APP}/package.json /app/apps/${APP}/package.json
 
-# see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypecache
 RUN \
       --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
       yarn --prefer-offline --frozen-lockfile
@@ -37,10 +32,8 @@ RUN \
 COPY --from=pruned /app/out/full/ .
 COPY turbo.json turbo.json
 
-# For example: `--filter=frontend^...` means all of frontend's dependencies will be built, but not the frontend app itself (which we don't need to do for dev environment)
 RUN turbo run build --no-cache --filter=${APP}^...
 
-# re-running yarn ensures that dependencies between workspaces are linked correctly
 RUN \
       --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
       yarn --prefer-offline --frozen-lockfile
@@ -58,4 +51,6 @@ RUN chmod +x /app/packages/db/init-db.sh
 EXPOSE 8080
 EXPOSE 5173
 EXPOSE 3000
+EXPOSE 5432
+
 CMD yarn workspace ${APP} ${START_COMMAND}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,95 @@
-## Chess
+<h1 align='center'>Chess</h1>
 
-Building a platform where people can
+## Table of contents
 
-1. Sign up
-2. Create a new match/get connected to an existing match
-3. During the match, let users play moves
-4. Have a rating system that goes up and down similar to standard chess rating
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+  - [Using Docker](#using-docker)
+  - [Without Docker](#without-docker)
+- [Usage](#usage)
+- [Contributing](#contributing)
 
-## Tech stack
+## Prerequisites
 
-Let's keep it simple
+Before you begin, ensure you have met the following requirements
 
-1. React for Frontend
-2. Node.js for Backend
-3. Typescript as the language
-4. Separate Websocket servers for handling real time games
-5. Redis for storing all moves of a game in a queue
+- Node.js and npm installed on your machine.
+- Docker and docker-compose installed (optional, required for Docker setup).
+- Access to a PostgreSQL database (can be local or hosted).
+- Google OAuth Client Credentials
+
+## Setup
+
+### Using Docker
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/code100x/chess.git
+   ```
+2. Navigate to the project directory:
+   ```bash
+   cd chess
+   ```
+3. Copy the `.env.example` in
+   `/apps/frontend`
+   `/apps/backend`
+   `/packages/db`
+   to `.env` in the same directory
+4. Replace the Google Client ID and Secret in the `/apps/backend/.env` file.
+5. Run the following command to start the application:
+   ```bash
+   docker-compose up
+   ```
+
+### Without Docker
+
+1. clone the repository:
+   ```bash
+   git clone https://github.com/code100x/chess.git
+   ```
+2. Navigate to the project directory:
+   ```bash
+   cd chess
+   ```
+3. (optional) Start a PostgreSQL database using Docker:
+   ```bash
+   docker run -d \
+       --name chess100x \
+       -e POSTGRES_USER=postgres \
+       -e POSTGRES_PASSWORD=chess100x \
+       -e POSTGRES_DB=chess100x \
+       -p 5432:5432 \
+       postgres
+   ```
+   based on this command the connection url will be
+   ```
+   DATABASE_URL=postgresql://postgres:chess100x@localhost:5432/chess100x?schema=public
+   ```
+4. Copy the `.env.example` in
+   `/apps/frontend`
+   `/apps/backend`
+   `/packages/db`
+   to `.env` in the same directory
+5. Replace the Google Client ID and Secret in the `/apps/backend/.env` file.
+6. Install dependencies:
+   ```bash
+   yarn install
+   ```
+7. Run database init in the `/packages/db` folder:
+   ```bash
+   yarn run db:dev
+   ```
+8. Start the development server:
+   ```bash
+   yarn run dev
+   ```
+   
+## Contributing
+
+We welcome contributions from the community! To contribute to CMS, follow these steps:
+
+1. Fork the repository.
+2. Create a new branch (`git checkout -b feature/fooBar`).
+3. Make your changes and commit them (`git commit -am 'Add some fooBar'`).
+4. Push to the branch (`git push origin feature/fooBar`).
+5. Create a new Pull Request.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 - [Setup](#setup)
   - [Using Docker](#using-docker)
   - [Without Docker](#without-docker)
-- [Usage](#usage)
 - [Contributing](#contributing)
 
 ## Prerequisites
@@ -36,7 +35,12 @@ Before you begin, ensure you have met the following requirements
    `/packages/db`
    to `.env` in the same directory
 4. Replace the Google Client ID and Secret in the `/apps/backend/.env` file.
-5. Run the following command to start the application:
+5. Update the DatabaseURL in the `/packages/db/.env`
+    ```bash
+   DATABASE_URL="postgresql://postgres:chess100x@172.20.0.8:5432/chess100x"
+    ```
+7. Run `yarn db:dev` in the `/packages/db`
+8. Run the following command to start the application:
    ```bash
    docker-compose up
    ```
@@ -71,7 +75,7 @@ Before you begin, ensure you have met the following requirements
    `/packages/db`
    to `.env` in the same directory
 5. Replace the Google Client ID and Secret in the `/apps/backend/.env` file.
-6. Install dependencies:
+6. Install dependencies in the root dir:
    ```bash
    yarn install
    ```
@@ -79,14 +83,14 @@ Before you begin, ensure you have met the following requirements
    ```bash
    yarn run db:dev
    ```
-8. Start the development server:
+8. Start the development server in the root dir:
    ```bash
    yarn run dev
    ```
    
 ## Contributing
 
-We welcome contributions from the community! To contribute to CMS, follow these steps:
+We welcome contributions from the community! To contribute to Chess, follow these steps:
 
 1. Fork the repository.
 2. Create a new branch (`git checkout -b feature/fooBar`).

--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+build
+.git
+*.md
+.gitignore

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,6 +16,7 @@
     "@types/express-session": "^1.18.0",
     "cookie-session": "^2.1.0",
     "cors": "^2.8.5",
+    "esbuild": "^0.20.2",
     "express": "^4.19.2",
     "express-session": "^1.18.0",
     "jsonwebtoken": "^9.0.2",

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,5 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-const client = new PrismaClient();
-
-export const db = client;

--- a/apps/backend/src/passport.ts
+++ b/apps/backend/src/passport.ts
@@ -3,7 +3,7 @@ const GithubStrategy = require('passport-github2').Strategy;
 const FacebookStrategy = require('passport-facebook').Strategy;
 import passport from 'passport';
 import dotenv from 'dotenv';
-import { db } from './db';
+import db from '@repo/db/client';
 
 dotenv.config();
 const GOOGLE_CLIENT_ID =

--- a/apps/backend/src/router/auth.ts
+++ b/apps/backend/src/router/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
-import { db } from '../db';
+import db from '@repo/db/client';
 const router = Router();
 
 const CLIENT_URL =

--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+build
+.git
+*.md
+.gitignore

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+    watch: {
+      usePolling: true,
+    },
+  },
 });

--- a/apps/ws/.dockerignore
+++ b/apps/ws/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+build
+.git
+*.md
+.gitignore

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "backend1",
+  "name": "ws",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "esbuild ./src/index.ts --bundle --platform=node --outfile=dist/index.js --sourcemap && node dist/index.js"
+    "dev": "npx esbuild ./src/index.ts --bundle --platform=node --outfile=dist/index.js --sourcemap && node dist/index.js"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +14,8 @@
     "@repo/db": "*",
     "@types/ws": "^8.5.10",
     "chess.js": "^1.0.0-beta.8",
+    "esbuild": "^0.20.2",
+    "eslint": "^8.57.0",
     "jsonwebtoken": "^9.0.2",
     "ws": "^8.16.0"
   },

--- a/apps/ws/src/Game.ts
+++ b/apps/ws/src/Game.ts
@@ -4,7 +4,7 @@ import {
   INIT_GAME,
   MOVE,
 } from './messages';
-import { db } from './db';
+import db from '@repo/db/client';
 import { randomUUID } from 'crypto';
 import { SocketManager, User } from './SocketManager';
 

--- a/apps/ws/src/GameManager.ts
+++ b/apps/ws/src/GameManager.ts
@@ -12,7 +12,7 @@ import {
   GAME_ADDED,
 } from './messages';
 import { Game, isPromoting } from './Game';
-import { db } from './db';
+import db from '@repo/db/client';
 import { SocketManager, User } from './SocketManager';
 import { Square } from 'chess.js';
 

--- a/apps/ws/src/db/index.ts
+++ b/apps/ws/src/db/index.ts
@@ -1,5 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-const client = new PrismaClient();
-
-export const db = client;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,90 @@
+version: '3.8'
+
+networks:
+  chess100x:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
+services:
+  postgres:
+    healthcheck:
+      test: pg_isready -h localhost -U postgres
+      interval: 2s
+      timeout: 5s
+      retries: 15
+    networks:
+      chess100x:
+        ipv4_address: 172.20.0.8
+    image: postgres:14-alpine
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_PASSWORD=chess100x
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=chess100x
+  backend:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      chess100x:
+        ipv4_address: 172.20.0.5
+    ports:
+      - 3000:3000
+    command: yarn workspace backend dev
+    environment:
+      - PORT=3000
+    build:
+      args:
+        APP: backend
+        START_COMMAND: dev
+      context: .
+      dockerfile: ./Dockerfile.dev
+    entrypoint: '/bin/sh /usr/app/packages/db/init-db.sh'
+    volumes:
+      - ./init-db.sh:/usr/app/packages/db/init-db.sh
+      - ./apps/backend:/app/apps/backend
+      - /app/apps/backend/node_modules
+  frontend:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      chess100x:
+        ipv4_address: 172.20.0.6
+    ports:
+      - 5173:5173
+    command: yarn workspace frontend dev
+    environment:
+      - PORT=5173
+    build:
+      args:
+        APP: frontend
+        START_COMMAND: dev
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./apps/frontend:/app/apps/frontend
+      - /app/apps/frontend/node_modules
+  ws:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      chess100x:
+        ipv4_address: 172.20.0.7
+    ports:
+      - 8080:8080
+    command: yarn workspace ws dev
+    environment:
+      - PORT=8080
+    build:
+      args:
+        APP: ws
+        START_COMMAND: dev
+      context: .
+      dockerfile: ./Dockerfile.dev
+    volumes:
+      - ./apps/ws:/app/apps/ws
+      - /app/apps/ws/node_modules

--- a/init-db.sh
+++ b/init-db.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /app/packages/db && npx prisma migrate dev && npx prisma generate
+cd /app/apps/backend && yarn run dev

--- a/packages/db/.env.development
+++ b/packages/db/.env.development
@@ -1,1 +1,0 @@
-DATABASE_URL="postgresql://postgres:chess100x@172.20.0.8:5432/chess100x"

--- a/packages/db/.env.development
+++ b/packages/db/.env.development
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://postgres:chess100x@172.20.0.8:5432/chess100x"

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"
+DATABASE_URL="postgresql://postgres:chess100x@172.20.0.8:5432/chess100x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,7 +5031,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.20.1, esbuild@^0.20.2:
+esbuild@^0.20.1:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.2.tgz#9d6b2386561766ee6b5a55196c6d766d28c87ea1"
   integrity sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==
@@ -8852,13 +8852,6 @@ rc@^1.0.1, rc@^1.1.6, rc@~1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-confetti@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-6.1.0.tgz#03dc4340d955acd10b174dbf301f374a06e29ce6"
-  integrity sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==
-  dependencies:
-    tween-functions "^1.2.0"
-
 react-devtools-core@^4.27.7:
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.28.5.tgz#c8442b91f068cdf0c899c543907f7f27d79c2508"
@@ -9863,16 +9856,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9950,7 +9934,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9963,13 +9947,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -10421,11 +10398,6 @@ turbo@latest:
     turbo-linux-arm64 "1.13.2"
     turbo-windows-64 "1.13.2"
     turbo-windows-arm64 "1.13.2"
-
-tween-functions@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
-  integrity sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -10934,7 +10906,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10947,15 +10919,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,7 +5031,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.20.1:
+esbuild@^0.20.1, esbuild@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.2.tgz#9d6b2386561766ee6b5a55196c6d766d28c87ea1"
   integrity sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==
@@ -8852,6 +8852,13 @@ rc@^1.0.1, rc@^1.1.6, rc@~1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-confetti@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-6.1.0.tgz#03dc4340d955acd10b174dbf301f374a06e29ce6"
+  integrity sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==
+  dependencies:
+    tween-functions "^1.2.0"
+
 react-devtools-core@^4.27.7:
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.28.5.tgz#c8442b91f068cdf0c899c543907f7f27d79c2508"
@@ -9856,7 +9863,16 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9934,7 +9950,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9947,6 +9963,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -10398,6 +10421,11 @@ turbo@latest:
     turbo-linux-arm64 "1.13.2"
     turbo-windows-64 "1.13.2"
     turbo-windows-arm64 "1.13.2"
+
+tween-functions@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
+  integrity sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -10906,7 +10934,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10919,6 +10947,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Checklist:

- [ ] Created docker-compose development environment. Closes #183 
- [ ] Fixed #230 Wrong usage of PrismaClient. Backend and WS was using a separate PrismaClient rather than the export at @repo/db/client
- [ ] Added esbuild which keeps failing the `turbo build` in the compose

Previous PR regarding docker-compose
#219 and #205 not seems to work as expected. As this is a monorepo. This PR is done how the monorepos should be dockerized.