### PR TITLE
feat: Game End Popup / Game Status updates

### DIFF
--- a/apps/frontend/src/components/GameEndModal.tsx
+++ b/apps/frontend/src/components/GameEndModal.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import WhiteKing from '../../public/wk.png';
+import BlackKing from '../../public/bk.png';
+import { GameResult } from '@/screens/Game';
+
+interface ModalProps {
+  blackPlayer?: { id: string; name: string };
+  whitePlayer?: { id: string; name: string };
+  gameResult: GameResult;
+  onClose: () => void;
+}
+
+const GameEndModal: React.FC<ModalProps> = ({
+  blackPlayer,
+  whitePlayer,
+  gameResult,
+  onClose,
+}) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const closeModal = () => {
+    setIsOpen(false);
+    onClose();
+  };
+
+  const getPlayerName = (player: { id: string; name: string } | undefined) => {
+    return player ? player.name : 'Unknown';
+  };
+
+  const getWinnerName = () => {
+    if (gameResult.result === 'BLACK_WINS') {
+      return getPlayerName(blackPlayer);
+    } else if (gameResult.result === 'WHITE_WINS') {
+      return getPlayerName(whitePlayer);
+    } else {
+      return 'Draw';
+    }
+  };
+
+  return (
+    <div>
+      {isOpen && (
+        <div className="fixed inset-0 flex items-center justify-center z-50 rounded">
+          <div className="absolute inset-0 bg-gray-900 opacity-75"></div>
+          <div className="relative rounded-lg shadow-lg bg-gray-800 w-96">
+            <div className="px-6 py-8 items-center self-center m-auto">
+              <div className="m-auto mb-6">
+                <h2 className={`text-4xl font-bold mb-2 text-yellow-400 text-center text-wrap`}>
+                  {gameResult.result === 'BLACK_WINS' ? 'Black Wins!' : gameResult.result === 'DRAW' ? `It's a Draw` : 'White Wins!'}  
+                </h2>
+              </div>
+              <div className="m-auto mb-6">
+                <p className="text-xl text-white text-center">by {gameResult.by}</p>
+              </div>
+              <div className="flex flex-row justify-between items-center bg-gray-700 rounded-lg px-4 py-6">
+                <div className="flex items-center">
+                  <div className="flex flex-col items-center">
+                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'WHITE_WINS' ? 'border-green-400' : 'border-red-400'} mr-4`}>
+                      <img src={WhiteKing} alt="White King" className="w-10 h-10" />
+                    </div>
+                    <div className="text-center text-xm p-2">
+                      <p className="text-white truncate w-24" title={getPlayerName(whitePlayer)}>{getPlayerName(whitePlayer)}</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="text-white text-2xl font-bold">vs</div>
+                <div className="flex items-center">
+                  <div className="flex flex-col items-center">
+                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'BLACK_WINS' ? 'border-green-400' : 'border-red-400'} ml-4`}>
+                      <img src={BlackKing} alt="Black King" className="w-10 h-10" />
+                    </div>
+                    <div className="text-center text-xm p-2">
+                        <p className="text-white truncate w-24" title={getPlayerName(blackPlayer)}>{getPlayerName(blackPlayer)}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="px-6 py-4 bg-gray-900 text-right rounded-b-lg">
+              <button
+                className="px-6 py-3 text-white bg-red-600 rounded-lg hover:bg-red-700 focus:outline-none"
+                onClick={closeModal}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GameEndModal;

--- a/apps/frontend/src/components/GameEndModal.tsx
+++ b/apps/frontend/src/components/GameEndModal.tsx
@@ -1,40 +1,71 @@
 import React, { useState } from 'react';
 import WhiteKing from '../../public/wk.png';
 import BlackKing from '../../public/bk.png';
-import { GameResult } from '@/screens/Game';
+import { GameResult, Result } from '@/screens/Game';
 
 interface ModalProps {
   blackPlayer?: { id: string; name: string };
   whitePlayer?: { id: string; name: string };
   gameResult: GameResult;
-  onClose: () => void;
 }
 
 const GameEndModal: React.FC<ModalProps> = ({
   blackPlayer,
   whitePlayer,
   gameResult,
-  onClose,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
 
   const closeModal = () => {
     setIsOpen(false);
-    onClose();
+  };
+
+  const PlayerDisplay = ({
+    player,
+    gameResult,
+    isWhite,
+  }: {
+    player?: { id: string; name: string };
+    gameResult: Result;
+    isWhite: boolean;
+  }) => {
+    const imageSrc = isWhite ? WhiteKing : BlackKing;
+    const borderColor =
+      gameResult === (isWhite ? Result.WHITE_WINS : Result.BLACK_WINS)
+        ? 'border-green-400'
+        : 'border-red-400';
+
+    return (
+      <div className="flex flex-col items-center">
+        <div className={`border-4 rounded-full p-2 ${borderColor}`}>
+          <img
+            src={imageSrc}
+            alt={`${isWhite ? 'White' : 'Black'} King`}
+            className="w-10 h-10"
+          />
+        </div>
+        <div className="text-center text-xm p-2">
+          <p className="text-white truncate w-24" title={getPlayerName(player)}>
+            {getPlayerName(player)}
+          </p>
+        </div>
+      </div>
+    );
+  };
+
+  const getWinnerMessage = (result: Result) => {
+    switch (result) {
+      case Result.BLACK_WINS:
+        return 'Black Wins!';
+      case Result.WHITE_WINS:
+        return 'White Wins!';
+      default:
+        return "It's a Draw";
+    }
   };
 
   const getPlayerName = (player: { id: string; name: string } | undefined) => {
     return player ? player.name : 'Unknown';
-  };
-
-  const getWinnerName = () => {
-    if (gameResult.result === 'BLACK_WINS') {
-      return getPlayerName(blackPlayer);
-    } else if (gameResult.result === 'WHITE_WINS') {
-      return getPlayerName(whitePlayer);
-    } else {
-      return 'Draw';
-    }
   };
 
   return (
@@ -46,34 +77,16 @@ const GameEndModal: React.FC<ModalProps> = ({
             <div className="px-6 py-8 items-center self-center m-auto">
               <div className="m-auto mb-6">
                 <h2 className={`text-4xl font-bold mb-2 text-yellow-400 text-center text-wrap`}>
-                  {gameResult.result === 'BLACK_WINS' ? 'Black Wins!' : gameResult.result === 'DRAW' ? `It's a Draw` : 'White Wins!'}  
+                 {getWinnerMessage(gameResult.result)}  
                 </h2>
               </div>
               <div className="m-auto mb-6">
                 <p className="text-xl text-white text-center">by {gameResult.by}</p>
               </div>
               <div className="flex flex-row justify-between items-center bg-gray-700 rounded-lg px-4 py-6">
-                <div className="flex items-center">
-                  <div className="flex flex-col items-center">
-                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'WHITE_WINS' ? 'border-green-400' : 'border-red-400'}`}>
-                      <img src={WhiteKing} alt="White King" className="w-10 h-10" />
-                    </div>
-                    <div className="text-center text-xm p-2">
-                      <p className="text-white truncate w-24" title={getPlayerName(whitePlayer)}>{getPlayerName(whitePlayer)}</p>
-                    </div>
-                  </div>
-                </div>
+                <PlayerDisplay isWhite={true} player={whitePlayer} gameResult={gameResult.result} />
                 <div className="text-white text-2xl font-bold">vs</div>
-                <div className="flex items-center">
-                  <div className="flex flex-col items-center">
-                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'BLACK_WINS' ? 'border-green-400' : 'border-red-400'}`}>
-                      <img src={BlackKing} alt="Black King" className="w-10 h-10" />
-                    </div>
-                    <div className="text-center text-xm p-2">
-                        <p className="text-white truncate w-24" title={getPlayerName(blackPlayer)}>{getPlayerName(blackPlayer)}</p>
-                    </div>
-                  </div>
-                </div>
+                <PlayerDisplay isWhite={false} player={blackPlayer} gameResult={gameResult.result} />
               </div>
             </div>
             <div className="px-6 py-4 bg-gray-900 text-right rounded-b-lg">

--- a/apps/frontend/src/components/GameEndModal.tsx
+++ b/apps/frontend/src/components/GameEndModal.tsx
@@ -55,7 +55,7 @@ const GameEndModal: React.FC<ModalProps> = ({
               <div className="flex flex-row justify-between items-center bg-gray-700 rounded-lg px-4 py-6">
                 <div className="flex items-center">
                   <div className="flex flex-col items-center">
-                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'WHITE_WINS' ? 'border-green-400' : 'border-red-400'} mr-4`}>
+                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'WHITE_WINS' ? 'border-green-400' : 'border-red-400'}`}>
                       <img src={WhiteKing} alt="White King" className="w-10 h-10" />
                     </div>
                     <div className="text-center text-xm p-2">
@@ -66,7 +66,7 @@ const GameEndModal: React.FC<ModalProps> = ({
                 <div className="text-white text-2xl font-bold">vs</div>
                 <div className="flex items-center">
                   <div className="flex flex-col items-center">
-                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'BLACK_WINS' ? 'border-green-400' : 'border-red-400'} ml-4`}>
+                    <div className={`border-4 rounded-full p-2 ${gameResult.result === 'BLACK_WINS' ? 'border-green-400' : 'border-red-400'}`}>
                       <img src={BlackKing} alt="Black King" className="w-10 h-10" />
                     </div>
                     <div className="text-center text-xm p-2">

--- a/apps/frontend/src/screens/Game.tsx
+++ b/apps/frontend/src/screens/Game.tsx
@@ -22,12 +22,19 @@ export const GAME_ALERT = 'game_alert';
 export const GAME_ADDED = 'game_added';
 export const USER_TIMEOUT = 'user_timeout';
 export const GAME_TIME = 'game_time';
+export const GAME_ENDED = 'game_ended';
+export interface GameResult {
+  result: 'WHITE_WINS' | 'BLACK_WINS' | 'DRAW';
+  by: string;
+}
+
 
 const GAME_TIME_MS = 10 * 60 * 1000;
 
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { movesAtom, userSelectedMoveIndexAtom } from '@repo/store/chessBoard';
+import GameEndModal from '@/components/GameEndModal';
 
 const moveAudio = new Audio(MoveSound);
 
@@ -49,11 +56,7 @@ export const Game = () => {
   const [started, setStarted] = useState(false);
   const [gameMetadata, setGameMetadata] = useState<Metadata | null>(null);
   const [result, setResult] = useState<
-    | 'WHITE_WINS'
-    | 'BLACK_WINS'
-    | 'DRAW'
-    | typeof OPPONENT_DISCONNECTED
-    | typeof USER_TIMEOUT
+    GameResult
     | null
   >(null);
   const [player1TimeConsumed, setPlayer1TimeConsumed] = useState(0);
@@ -122,8 +125,26 @@ export const Game = () => {
           setResult(message.payload.result);
           break;
 
-        case OPPONENT_DISCONNECTED:
-          setResult(OPPONENT_DISCONNECTED);
+        case GAME_ENDED:
+          const wonBy = message.payload.status === 'COMPLETED' ? 
+            message.payload.result !== 'DRAW' ? 'CheckMate' : 'Draw' : 'Timeout';
+          setResult({
+            result: message.payload.result,
+            by: wonBy,
+          });
+          chess.reset();
+          setMoves(() => {
+            message.payload.moves.map((curr_move: Move) => {
+              chess.move(curr_move as Move);
+            });
+            return message.payload.moves;
+          });
+          setGameMetadata({
+            blackPlayer: message.payload.blackPlayer,
+            whitePlayer: message.payload.whitePlayer,
+          });
+          
+        
           break;
 
         case USER_TIMEOUT:
@@ -205,11 +226,14 @@ export const Game = () => {
   return (
     <div className="">
       {result && (
-        <div className="justify-center flex pt-4 text-white">
-          {result === 'WHITE_WINS' && 'White wins'}
-          {result === 'BLACK_WINS' && 'Black wins'}
-          {result === 'DRAW' && 'Draw'}
-        </div>
+        <GameEndModal
+          blackPlayer={gameMetadata?.blackPlayer}
+          whitePlayer={gameMetadata?.whitePlayer}
+          gameResult={result}
+          onClose={() => {
+            console.log('closing');
+          }}
+        ></GameEndModal>
       )}
       {started && (
         <div className="justify-center flex pt-4 text-white">
@@ -220,9 +244,9 @@ export const Game = () => {
         </div>
       )}
       <div className="justify-center flex">
-        <div className="pt-2 max-w-screen-xl w-full">
-          <div className="grid grid-cols-7 w-full">
-            <div className={`col-span-7 lg:col-span-4 w-full text-white ${(result === OPPONENT_DISCONNECTED || result === USER_TIMEOUT) ? 'pointer-events-none':""}`}>
+        <div className="pt-2 w-full">
+          <div className="flex flex-wrap justify-around content-around w-full">
+            <div className="text-white">
               <div className="flex justify-center">
                 <div>
                   <div className="mb-4">
@@ -245,7 +269,7 @@ export const Game = () => {
                   </div>
                   <div>
                     <div
-                      className={`col-span-4 w-full flex justify-center text-white`}
+                      className={`w-full flex justify-center text-white`}
                     >
                       <ChessBoard
                         started={started}
@@ -279,7 +303,7 @@ export const Game = () => {
                 </div>
               </div>
             </div>
-            <div className="col-span-3 rounded-md bg-brown-500 w-full h-[90vh] overflow-auto mt-10">
+            <div className="rounded-md bg-brown-500 overflow-auto h-[90vh] mt-10">
               {!started && (
                 <div className="pt-8 flex justify-center w-full">
                   {added ? (

--- a/apps/frontend/src/screens/Game.tsx
+++ b/apps/frontend/src/screens/Game.tsx
@@ -23,8 +23,13 @@ export const GAME_ADDED = 'game_added';
 export const USER_TIMEOUT = 'user_timeout';
 export const GAME_TIME = 'game_time';
 export const GAME_ENDED = 'game_ended';
+export enum Result {
+  WHITE_WINS = 'WHITE_WINS',
+  BLACK_WINS = 'BLACK_WINS',
+  DRAW = 'DRAW',
+}
 export interface GameResult {
-  result: 'WHITE_WINS' | 'BLACK_WINS' | 'DRAW';
+  result: Result;
   by: string;
 }
 
@@ -230,9 +235,6 @@ export const Game = () => {
           blackPlayer={gameMetadata?.blackPlayer}
           whitePlayer={gameMetadata?.whitePlayer}
           gameResult={result}
-          onClose={() => {
-            console.log('closing');
-          }}
         ></GameEndModal>
       )}
       {started && (

--- a/apps/ws/src/Game.ts
+++ b/apps/ws/src/Game.ts
@@ -351,6 +351,13 @@ export class Game {
         },
       }),
     );
+    // clear timers
+    this.clearTimer();
+    this.clearMoveTimer();
+  }
+
+  clearMoveTimer() {
+    if(this.moveTimer) clearTimeout(this.moveTimer);
   }
 
   setTimer(timer: NodeJS.Timeout) {

--- a/apps/ws/src/Game.ts
+++ b/apps/ws/src/Game.ts
@@ -313,7 +313,7 @@ export class Game {
   }
 
   async endGame(status: GAME_STATUS, result: GAME_RESULT) {
-    await db.game.update({
+    const updatedGame = await db.game.update({
       data: {
         status,
         result: result,
@@ -321,6 +321,15 @@ export class Game {
       where: {
         id: this.gameId,
       },
+      include: {
+        moves: {
+          orderBy: {
+            moveNumber: 'asc',
+          },
+        },
+        blackPlayer: true,
+        whitePlayer: true,
+      }
     });
 
     SocketManager.getInstance().broadcast(
@@ -329,7 +338,16 @@ export class Game {
         type: GAME_ENDED,
         payload: {
           result,
-          status
+          status,
+          moves: updatedGame.moves,
+          blackPlayer: {
+            id: updatedGame.blackPlayer.id,
+            name: updatedGame.blackPlayer.name,
+          },
+          whitePlayer: {
+            id: updatedGame.whitePlayer.id,
+            name: updatedGame.whitePlayer.name,
+          },
         },
       }),
     );

--- a/apps/ws/src/GameManager.ts
+++ b/apps/ws/src/GameManager.ts
@@ -10,11 +10,13 @@ import {
   GAME_NOT_FOUND,
   GAME_ALERT,
   GAME_ADDED,
+  GAME_ENDED,
 } from './messages';
 import { Game, isPromoting } from './Game';
 import { db } from './db';
 import { SocketManager, User } from './SocketManager';
 import { Square } from 'chess.js';
+import { GameStatus } from '@prisma/client';
 
 export class GameManager {
   private games: Game[];
@@ -122,6 +124,26 @@ export class GameManager {
               type: GAME_NOT_FOUND,
             }),
           );
+          return;
+        }
+
+        if(gameFromDb.status !== GameStatus.IN_PROGRESS) {
+          user.socket.send(JSON.stringify({
+            type: GAME_ENDED,
+            payload: {
+              result: gameFromDb.result,
+              status: gameFromDb.status,
+              moves: gameFromDb.moves,
+              blackPlayer: {
+                id: gameFromDb.blackPlayer.id,
+                name: gameFromDb.blackPlayer.name,
+              },
+              whitePlayer: {
+                id: gameFromDb.whitePlayer.id,
+                name: gameFromDb.whitePlayer.name,
+              },
+            }
+          }));
           return;
         }
 


### PR DESCRIPTION
- Added Modal for Displaying Game Results when Game is completed
- Fixed Game Status being updated to Abandoned even when game is completed, was happening due to intervals not being cleared on game end.
- Not Allowing to resume a already ended game, otherwise it was being resumed on reloading.
- Ui Updates for chess board and Move Tables being overlapped

Game Result Modal
<img width="1175" alt="image" src="https://github.com/code100x/chess/assets/61278001/a96cc34b-4221-47e1-842f-7ee1278b5adb">
Fixed Ui for Game Page, now they are not overlapping 
![image](https://github.com/code100x/chess/assets/61278001/7105f420-8bd1-4228-ba7e-441e7b15e491)
