### PR TITLE
Fixed login error redirect and also added toast notification for sign,signout and login error 

### DIFF
--- a/apps/backend/src/router/auth.ts
+++ b/apps/backend/src/router/auth.ts
@@ -47,7 +47,7 @@ router.get('/logout', (req: Request, res: Response) => {
       res.status(500).json({ error: 'Failed to log out' });
     } else {
       res.clearCookie('jwt');
-      res.redirect('http://localhost:5173/');
+      res.redirect('http://localhost:5173/?status=logout');
     }
   });
 });
@@ -60,8 +60,8 @@ router.get(
 router.get(
   '/google/callback',
   passport.authenticate('google', {
-    successRedirect: CLIENT_URL,
-    failureRedirect: '/login/failed',
+    successRedirect: `${CLIENT_URL}?login=success`,
+    failureRedirect: `${CLIENT_URL}?login=failed`,
   }),
 );
 
@@ -73,8 +73,8 @@ router.get(
 router.get(
   '/github/callback',
   passport.authenticate('github', {
-    successRedirect: CLIENT_URL,
-    failureRedirect: '/login/failed',
+    successRedirect: `${CLIENT_URL}?login=success`,
+    failureRedirect: `${CLIENT_URL}?login=failed`,
   }),
 );
 
@@ -86,8 +86,8 @@ router.get(
 router.get(
   '/facebook/callback',
   passport.authenticate('facebook', {
-    successRedirect: CLIENT_URL,
-    failureRedirect: '/login/failed',
+    successRedirect: `${CLIENT_URL}?login=success`,
+    failureRedirect: `${CLIENT_URL}?login=failed`,
   }),
 );
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -25,6 +25,7 @@
     "react-confetti": "^6.1.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
+    "react-toastify": "^10.0.5",
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",

--- a/apps/frontend/src/screens/Landing.tsx
+++ b/apps/frontend/src/screens/Landing.tsx
@@ -1,8 +1,30 @@
 import { PlayCard } from '@/components/Card';
+import { useEffect } from 'react';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 export const Landing = () => {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get('login') === 'failed') {
+      toast.error('Login failed , Please try again later');
+    }
+    if (params.get('login') === 'success') {
+      toast.success('Login successful');
+    }
+    if (params.get('status') === 'logout') {
+      toast.warning('Signout successful');
+    }
+
+    params.delete('login');
+    const newUrl = window.location.pathname + params.toString();
+    window.history.replaceState({}, '', newUrl);
+  }, []);
+
   return (
     <div className="max-w-full h-screen chess-board mt-0">
+      <ToastContainer autoClose={3000} />
       <div className="flex flex-col md:flex-row w-full md:w-3/4 max-w-screen-lg mx-auto gap-x-4 p-4">
         <img
           className="rounded-md w-full md:h-3/4  hidden md:block"


### PR DESCRIPTION
Fixes #330

### Whenever user gets a login error he is redirected to home page instead of /login/failed

Also added toast notification for logout,login and login error to let user know

### Login error
![image](https://github.com/code100x/chess/assets/91898040/0d34f271-5cf1-4ccb-a3f4-bb79e0cec9f1)

### Login succesfull
![image](https://github.com/code100x/chess/assets/91898040/3b50ec86-cd3d-4ede-acbc-ab99f6456fa8)

### Signout
![image](https://github.com/code100x/chess/assets/91898040/749f71e5-854a-48c8-a189-6c7393d9971c)






