### PR TITLE
Fix for Issue #369: Resolve 'AuthProvider is not defined' Error for Guest Users

### DIFF
--- a/apps/ws/src/Game.ts
+++ b/apps/ws/src/Game.ts
@@ -7,6 +7,7 @@ import {
 import { db } from './db';
 import { randomUUID } from 'crypto';
 import { socketManager, User } from './SocketManager';
+import { AuthProvider } from '@prisma/client';
 
 type GAME_STATUS = 'IN_PROGRESS' | 'COMPLETED' | 'ABANDONED' | 'TIME_UP' | 'PLAYER_EXIT';
 type GAME_RESULT = "WHITE_WINS" | "BLACK_WINS" | "DRAW";


### PR DESCRIPTION
This pull request fixes Issue #369, where the game throws an error for Guest users due to **AuthProvider** being undefined.

**Changes Made:**

- Added the missing import([Commit](https://github.com/iammuhammadahmad/chess/commit/d5c9b8e5e878fb6ae3cc5b4a973bbc96991e2b6d)):

      `import { AuthProvider } from '@prisma/client';`  

- Ensured the game logic correctly handles Guest users without errors.

This fixes the error, ensuring smooth gameplay functionality for Guest users.